### PR TITLE
Remove download_history from clearon exit partial

### DIFF
--- a/configs/Configuration.config
+++ b/configs/Configuration.config
@@ -48,7 +48,7 @@
 		"Configs": {
 			"ClearBrowsingDataOnExitList": {
 				"Type": "Policy",
-				"Value": ["download_history","cached_images_and_files","autofill","hosted_app_data"]
+				"Value": ["cached_images_and_files","autofill","hosted_app_data"]
 			}
 		}
 	},


### PR DESCRIPTION
Since we are not clearing browsing_history, download_history should probably be kept as well.