### PR TITLE
docs: warn that dynamic-code-restriction (ACG) breaks JIT apps

### DIFF
--- a/configs/Configuration.config
+++ b/configs/Configuration.config
@@ -896,7 +896,7 @@
 		}
 	},
 	"enable-dynamic-code-restriction": {
-		"Description": "Uses ACG for the browser process to enforce W^X",
+		"Description": "Uses ACG for the browser process to enforce W^X. WARNING: breaks JIT-dependent Chromium/Electron apps (e.g. Codex)",
 		"Tags": ["SECURITY", "WINDOWS_ONLY"],
 		"Configs": {
 			"DynamicCodeSettings": {


### PR DESCRIPTION
#72 
DynamicCodeSettings=1 enables ACG, which is inherited by Chromium/Electron apps sharing the Policies\Google\Chrome key and breaks JIT-dependent apps such as OpenAI Codex.

Would it be okay to modify your repo like this? Feel free to do as you see fit.