### PR TITLE
chore: make disabling WebGPU optional

### DIFF
--- a/configs/Configuration.config
+++ b/configs/Configuration.config
@@ -796,7 +796,8 @@
 	},
 	"disable-webgpu": {
 		"Description": "Disable WebGPU, not provably secure yet",
-		"Tags": ["SECURITY", "PRIVACY"],
+		"Tags": ["SECURITY", "PRIVACY", "OPTIONAL"],
+		"Option": "Do you want to disable WebGPU? (websites depending on this feature will not work)",
 		"Configs": {
 			"WebGPUBlobCache": {
 				"Type": "Feature",


### PR DESCRIPTION
I have found some websites breaking when WebGPU is disabled (e.g. [Figma](https://help.figma.com/hc/en-us/articles/360039827194-What-are-the-system-requirements-for-Figma#browser)).

Currently, this setting does not have the `OPTIONAL` tag. Creating a custom configuration file or editing the one provided is required in order to remove this option. However, since many other website-breaking settings are optional (WebGL, JIT, etc.), I think we can make disabling WebGPU optional too.