### PR TITLE
Add manual workflow trigger to manually build site for Zensical updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,6 @@
 name: Deploy Site
 on:
+    workflow_dispatch:
     push:
         branches:
             - master


### PR DESCRIPTION
So the site can be rebuilt manually when a new version comes out.