### PR TITLE
Add NewTabPageLocation policy

### DIFF
--- a/configs/Configuration.config
+++ b/configs/Configuration.config
@@ -1043,7 +1043,7 @@
 		}
 	},
     "new-tab-page-location": {
-        "Description": "Blocks search enhines from taking over the new tab page.",
+        "Description": "Blocks search engines from taking over the new tab page.",
 		"Tags": ["Privacy"],
 		"Configs": {
 			"NewTabPageLocation": {

--- a/configs/Configuration.config
+++ b/configs/Configuration.config
@@ -1049,7 +1049,7 @@
 			"NewTabPageLocation": {
 				"Type": "Policy",
 				"Value": "chrome://new-tab-page-third-party",
-                "Recommendable": true
+				"Recommendable": true
 			}
 		}
 	},

--- a/configs/Configuration.config
+++ b/configs/Configuration.config
@@ -1042,6 +1042,17 @@
 			}
 		}
 	},
+    "new-tab-page-location": {
+        "Description": "Blocks search enhines from taking over the new tab page.",
+		"Tags": ["Privacy"],
+		"Configs": {
+			"NewTabPageLocation": {
+				"Type": "Policy",
+				"Value": "chrome://new-tab-page-third-party",
+                "Recommendable": true
+			}
+		}
+	},
 	"network-service-sandbox": {
 		"Description": "Enables various mitigations and restrictions for the network process",
 		"Tags": ["SECURITY"],


### PR DESCRIPTION
This policy sets the new tab page to a generic `chrome://new-tab-page-third-party`, so search engines like DuckDuckGo, when set as the main search provider, aren’t able to take over the new tab page, which slows down the browser and can introduce trackers just by opening a new tab.

If desired, the user can still set the homepage to any URL, which automatically negates this policy.