### PR TITLE
Make disable-hardware-acceleration distinguishable from its flag during config generation 

### DIFF
--- a/configs/Configuration.config
+++ b/configs/Configuration.config
@@ -405,7 +405,7 @@
 	"disable-hardware-acceleration": {
 		"Description": "Disable HWAccel, reduces attack surface and prevents some HW based fingerprinting but reduces performance, also disables WebGL and WebGPU if a software rendering alternative isn't available",
 		"Tags": ["SECURITY", "PRIVACY", "OPTIONAL"],
-		"Option": "Do you want to disable hardware acceleration? (this can cause performance slowdowns)",
+		"Option": "Do you want to disable hardware acceleration via policies? (this can cause performance slowdowns)",
 		"Configs": {
 			"HardwareAccelerationModeEnabled": {
 				"Type": "Policy",
@@ -417,7 +417,7 @@
 	"disable-hardware-acceleration-flag": {
 		"Description": "",
 		"Tags": ["SECURITY", "PRIVACY", "OPTIONAL"],
-		"Option": "Do you want to disable hardware acceleration? (this can cause performance slowdowns)",
+		"Option": "Do you want to disable hardware acceleration via flags? (this can cause performance slowdowns)",
 		"Configs": {
 			"disable-gpu": {
 				"Type": "Flag"


### PR DESCRIPTION
This way the user can tell the difference between the options. Currently it just looks like the question is being asked twice. 